### PR TITLE
implement table of contents into articles

### DIFF
--- a/src/articles/Articles.tsx
+++ b/src/articles/Articles.tsx
@@ -27,6 +27,7 @@ const sample_story: IArticle = {
       'https://raw.githubusercontent.com/4digitmwc/media-centre-articles/main/stories/sample.md',
     authors: [HowToPlayLN, Auxesiaa],
     image: 'https://media.discordapp.net/attachments/672354730814734336/994520362261950524/Background.png?width=1178&height=662',
+    table_of_content: false
   }
 }
 
@@ -39,7 +40,8 @@ const week0: IArticle = {
     },
     article_url: 'https://raw.githubusercontent.com/4digitmwc/media-centre-articles/main/stories/week0.md',
     authors: [Polytetral, HowToPlayLN],
-    image: 'https://media.discordapp.net/attachments/672354730814734336/994520362261950524/Background.png?width=1178&height=662'
+    image: 'https://media.discordapp.net/attachments/672354730814734336/994520362261950524/Background.png?width=1178&height=662',
+    table_of_content: false
   }
 }
 
@@ -52,7 +54,8 @@ const week1: IArticle = {
     },
     article_url: 'https://raw.githubusercontent.com/4digitmwc/media-centre-articles/main/stories/week1.md',
     authors: [HowToPlayLN],
-    image: 'https://media.discordapp.net/attachments/672354730814734336/994520362261950524/Background.png?width=1178&height=662'
+    image: 'https://media.discordapp.net/attachments/672354730814734336/994520362261950524/Background.png?width=1178&height=662',
+    table_of_content: false
   }
 }
 
@@ -65,7 +68,8 @@ const week2: IArticle = {
     },
     article_url: 'https://raw.githubusercontent.com/4digitmwc/media-centre-articles/main/stories/week2.md',
     authors: [Leon, Auxesiaa],
-    image: 'https://media.discordapp.net/attachments/672354730814734336/994520362261950524/Background.png?width=1178&height=662'
+    image: 'https://media.discordapp.net/attachments/672354730814734336/994520362261950524/Background.png?width=1178&height=662',
+    table_of_content: false
   }
 }
 
@@ -85,6 +89,7 @@ const sample_interview: IArticle = {
       'https://raw.githubusercontent.com/4digitmwc/media-centre-articles/main/interviews/sample.md',
     authors: [Arccat, TheFunk],
     image: 'https://media.discordapp.net/attachments/672354730814734336/994520362261950524/Background.png?width=1178&height=662',
+    table_of_content: false
   }
 }
 
@@ -100,6 +105,7 @@ const week1_interview: IArticle = {
       'https://raw.githubusercontent.com/4digitmwc/media-centre-articles/main/interviews/week1.md',
     authors: [Arccat, TheFunk, Polytetral],
     image: 'https://media.discordapp.net/attachments/672354730814734336/994520362261950524/Background.png?width=1178&height=662',
+    table_of_content: true
   }
 }
 
@@ -113,6 +119,7 @@ const week2_interview: IArticle = {
     article_url: 'https://raw.githubusercontent.com/4digitmwc/media-centre-articles/main/interviews/week2.md',
     authors: [Arccat, Polytetral, HowToPlayLN],
     image: 'https://media.discordapp.net/attachments/672354730814734336/994520362261950524/Background.png?width=1178&height=662',
+    table_of_content: true
   }
 }
 
@@ -133,6 +140,7 @@ const sample_opinion: IArticle = {
       'https://raw.githubusercontent.com/4digitmwc/media-centre-articles/main/opinions/sample.md',
     authors: [Auxesiaa, Polytetral],
     image: 'https://media.discordapp.net/attachments/672354730814734336/994520362261950524/Background.png?width=1178&height=662',
+    table_of_content: false
   }
 }
 
@@ -145,7 +153,8 @@ const week0_opinion: IArticle = {
     },
     article_url: "https://raw.githubusercontent.com/4digitmwc/media-centre-articles/main/opinions/week0.md",
     authors: [Polytetral],
-    image: 'https://media.discordapp.net/attachments/672354730814734336/994520362261950524/Background.png?width=1178&height=662'
+    image: 'https://media.discordapp.net/attachments/672354730814734336/994520362261950524/Background.png?width=1178&height=662',
+    table_of_content: true
   }
 }
 
@@ -158,7 +167,8 @@ const week1_opinion: IArticle = {
     },
     article_url: "https://raw.githubusercontent.com/4digitmwc/media-centre-articles/main/opinions/week1.md",
     authors: [Evening, Komi, HowToPlayLN],
-    image: "https://media.discordapp.net/attachments/672354730814734336/994520362261950524/Background.png?width=1178&height=662"
+    image: "https://media.discordapp.net/attachments/672354730814734336/994520362261950524/Background.png?width=1178&height=662",
+    table_of_content: false
   }
 }
 
@@ -171,7 +181,8 @@ const week2_opinion: IArticle = {
     },
     article_url: 'https://raw.githubusercontent.com/4digitmwc/media-centre-articles/main/opinions/week2.md',
     authors: [Auxesiaa],
-    image: "https://media.discordapp.net/attachments/672354730814734336/994520362261950524/Background.png?width=1178&height=662"
+    image: "https://media.discordapp.net/attachments/672354730814734336/994520362261950524/Background.png?width=1178&height=662",
+    table_of_content: true
   }
 }
 
@@ -191,6 +202,7 @@ const sample_highlight: IArticle = {
       'https://raw.githubusercontent.com/4digitmwc/media-centre-articles/main/highlights/sample.md',
     authors: [TheFunk],
     image: 'https://media.discordapp.net/attachments/672354730814734336/994520362261950524/Background.png?width=1178&height=662',
+    table_of_content: false
   }
 }
 
@@ -204,6 +216,7 @@ const ro32_highlight: IArticle = {
     article_url: "https://raw.githubusercontent.com/4digitmwc/media-centre-articles/main/highlights/ro32.md",
     authors: [Leon, HowToPlayLN],
     image: 'https://media.discordapp.net/attachments/672354730814734336/994520362261950524/Background.png?width=1178&height=662',
+    table_of_content: true
   }
 }
 

--- a/src/components/Article/Article.tsx
+++ b/src/components/Article/Article.tsx
@@ -1,15 +1,66 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import axios from 'axios';
+import generateSlug from '../../utils/generateSlug';
+import tableOfContents from '../../utils/tableOfContents';
 
 interface IArticle {
   article_url: string;
+  table_of_content: boolean
 }
 
 interface IState {
   article: string;
   loading: boolean;
   error: boolean;
+}
+
+const MarkdownComponent: object = {
+	h1: (props: any) => {
+		const arr = props.children 
+	  let heading = ''
+
+	  for (let i = 0; i < arr.length; i++) {
+	    if (arr[i]?.type !== undefined) {
+	      for (let j = 0; j < arr[i].props.children.length; j++) {
+	        heading += arr[i]?.props?.children[0]
+	      }
+	    } else heading += arr[i]
+	  }
+
+	  const slug = generateSlug(heading)
+	  return <h1 id={slug}>{props.children}</h1>
+	},
+	h2: (props: any) => {
+		const arr = props.children 
+	  let heading = ''
+
+	  for (let i = 0; i < arr.length; i++) {
+	    if (arr[i]?.type !== undefined) {
+	      for (let j = 0; j < arr[i].props.children.length; j++) {
+	        heading += arr[i]?.props?.children[0]
+	      }
+	    } else heading += arr[i]
+	  }
+
+	  const slug = generateSlug(heading)
+	  return <h2 id={slug}>{props.children}</h2>
+	},
+	h3: (props: any) => {
+		const arr = props.children 
+	  let heading = ''
+
+	  for (let i = 0; i < arr.length; i++) {
+	    if (arr[i]?.type !== undefined) {
+	      for (let j = 0; j < arr[i].props.children.length; j++) {
+	        heading += arr[i]?.props?.children[0]
+	      }
+	    } else heading += arr[i]
+	  }
+
+	  const slug = generateSlug(heading)
+	  return <h3 id={slug}>{props.children}</h3>
+	}
 }
 
 class Article extends React.Component<IArticle, IState> {
@@ -34,7 +85,13 @@ class Article extends React.Component<IArticle, IState> {
       this.setLoading(true);
       const article_response = await axios.get(this.props.article_url);
       const article_data = await article_response.data;
-      this.setArticle(article_data);
+      if (this.props.table_of_content) {
+        const table_of_content = tableOfContents(article_data)
+        this.setArticle(table_of_content + "\n---\n" + article_data)
+      }
+      else {
+        this.setArticle(article_data);
+      }
     } catch (error) {
       this.setError(true);
     } finally {
@@ -73,7 +130,7 @@ class Article extends React.Component<IArticle, IState> {
 
     return (
       <section style={{ width: '65%', textAlign: 'left', marginLeft: 40}}>
-        <ReactMarkdown>{this.state.article}</ReactMarkdown>
+        <ReactMarkdown components={MarkdownComponent}>{this.state.article}</ReactMarkdown>
       </section>
     );
   }

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -7,6 +7,7 @@ export interface IPost {
   image: string;
   header: IHeader;
   article_url: string;
+  table_of_content: boolean;
   authors: IProfile[];
 }
 
@@ -48,7 +49,7 @@ class Post extends React.Component<IPost, IState> {
             minHeight: "100vh"
           }}
         >
-          <Article article_url={this.props.article_url} />
+          <Article article_url={this.props.article_url} table_of_content={this.props.table_of_content} />
           {/* Profile */}
           <div style={{display: 'block'}}>
             {

--- a/src/utils/generateSlug.ts
+++ b/src/utils/generateSlug.ts
@@ -1,0 +1,19 @@
+const generateSlug = (str: string) => {
+
+    str = str?.replace(/^\s+|\s+$/g, '')
+    str = str?.toLowerCase()
+    const from = 'àáãäâèéëêìíïîòóöôùúüûñç·/_,:;'
+    const to   = 'aaaaaeeeeiiiioooouuuunc------'
+  
+    for (let i = 0, l = from.length; i < l; i++) {
+      str = str.replace(new RegExp(from.charAt(i), 'g'), to.charAt(i))
+    }
+  
+    str = str?.replace(/[^a-z0-9 -]/g, '')
+      .replace(/\s+/g, '-')
+      .replace(/-+/g, '-')
+  
+    return str
+  }
+  
+export default generateSlug

--- a/src/utils/tableOfContents.ts
+++ b/src/utils/tableOfContents.ts
@@ -1,0 +1,25 @@
+import generateSlug from "./generateSlug"
+
+const tableOfContents = (markdown: string) => {
+    const markdownLines = markdown.split("\n")
+    const headers = markdownLines.filter(md => {
+        return md.split(" ")[0][0] === "#" 
+    })
+    const tableContents = headers.map(header => {
+        const headerSplit = header.split(" ")
+        const headerContent = headerSplit.slice(1).join(" ")
+        const headerLevel = headerSplit[0].length
+        let content: string
+        if (headerLevel === 1) {
+            content = headerSplit.slice(1).join(" ")
+        }
+        else {
+            content = "\t".repeat(headerLevel - 2) + "- "
+            content += `[${headerContent}](#${generateSlug(headerContent)})`
+        }
+        return content
+    })
+    return "## Table of Contents\n" + tableContents.join("\n")
+}
+
+export default tableOfContents


### PR DESCRIPTION
# Implementation of Table of Contents into Media Centre Articles

We can choose whether to include table of contents into the articles by using the new attribute in IArticle, and table of contents will redirect to each header.

## Examples

This is the example for [Percy LNs Article](https://4digitmwc.github.io/media-centre/opinions/percy)

![](https://cdn.discordapp.com/attachments/1068591822944878612/1068719693717839932/image.png)